### PR TITLE
update window flags so they work better on a multi-monitor setup

### DIFF
--- a/addons/copy_files_on_export/manage_item_popup.tscn
+++ b/addons/copy_files_on_export/manage_item_popup.tscn
@@ -10,11 +10,11 @@ font_size = 12
 font_color = Color(1, 0, 0, 1)
 
 [node name="Popup" type="Window"]
-initial_position = 1
+initial_position = 4
 size = Vector2i(300, 450)
+visible = false
 transient = true
 exclusive = true
-popup_window = true
 script = ExtResource("1_0rh2a")
 action_text = "Add"
 


### PR DESCRIPTION
fix to address the multi-monitor issues described in #1 - primarily uncheck the `popup_window` flag which seemed to spawn the Add/Edit dialog below the Project Settings window making it seem like it did not spawn at all. This seemed to happen only when the Project Settings window was on the non-primary monitor (the location of the Godot window didn't seem to have an effect).

Also, turn "visible" to false, as it being true seems to interfere with the window now not being a `popup_window` anymore.

Also spawn add/edit dialog on the monitor which has the current mouse cursor to closer match the behavior of other Project Settings dialogs.

fixes #1 